### PR TITLE
Fix bug when decoding the sensor message.

### DIFF
--- a/pycreate2/create2api.py
+++ b/pycreate2/create2api.py
@@ -9,6 +9,7 @@
 
 from __future__ import print_function
 from __future__ import division
+import array
 import struct  # there are 2 places that use this ... why?
 import time
 from pycreate2.packets import SensorPacketDecoder
@@ -385,9 +386,9 @@ class Create2(object):
 
 		self.SCI.write(opcode, cmd)
 		time.sleep(0.015)  # wait 15 msec
-		packet_byte_data = list(self.SCI.read(sensor_pkt_len))
 
-		packet_byte_data = ''.join(packet_byte_data)  # FIXME: is this what i want? was an array, now a str
+		packet_byte_data = list(self.SCI.read(sensor_pkt_len))
+		packet_byte_data = array.array('B', packet_byte_data).tostring()
 
 		# print('-'*60)
 		# print('returned data len({})'.format(len(packet_byte_data)))


### PR DESCRIPTION
Previously when using methods that read the sensors one would see.

```
Traceback (most recent call last):
  File "T.py", line 18, in <module>
    bot.drive_distance(+0.05, 100)
  File "/tmp/pycreate2/create2api.py", line 276, in drive_distance
    sensors = self.get_sensors()
  File "/tmp/pycreate2/create2api.py", line 391, in get_sensors
    packet_byte_data = ''.join(packet_byte_data)  # FIXME: is this what i want? was an array, now a str
TypeError: sequence item 0: expected str instance, int found
```

This fixes that.